### PR TITLE
Add Dev Services support for MySQL

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Tell us about a problem you are experiencing
+title: ''
+labels: bug, triage
+assignees: ''
+
+---
+
+## What happened
+<!-- A small description of the issue -->
+
+## What did you expect
+<!-- A description of what was expected -->
+
+## What steps did you take
+<!-- A clear and concise description steps that can be used to reproduce the problem -->
+
+## Anything else you would like to add:
+<!-- Additional information that will assist in solving the issue -->
+
+## Environment
+
+* Java version:
+* Arconia version:
+* Build tool (Gradle/Maven):
+
+If relevant:
+
+* Container runtime (e.g. Podman, Docker):
+* IDE (e.g. IntelliJ IDEA, Visual Studio Code):

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement, triage
+assignees: ''
+
+---
+
+## Describe the problem/challenge you have
+<!-- A description of the current challenge that you are experiencing -->
+
+## Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. If applicable, include a visual representation -->
+
+## Anything else you would like to add
+<!-- Additional information that will assist in solving the issue -->

--- a/.github/ISSUE_TEMPLATE/other-request.md
+++ b/.github/ISSUE_TEMPLATE/other-request.md
@@ -1,0 +1,8 @@
+---
+name: Other issue or question
+about: Free form issue or question
+title: ''
+labels: triage
+assignees: ''
+
+---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+**IMPORTANT: Please do not submit a Pull Request without creating an issue first.**
+
+*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*
+
+Thank you for taking time to contribute this pull request!
+
+## Issue
+<!-- Link to the issue that this pull request addresses. If it doesn't exist, please create one. -->
+
+## Description
+<!-- A small description of the change -->
+
+## Checklist
+
+- [ ] I have rebased my changes on the latest `main` branch
+- [ ] I have squashed my commits into a single commit
+- [ ] I have added tests to cover my changes
+- [ ] I have run a build and made sure all tests pass (`./gradlew build`)
+- [ ] I have added/updated relevant documentation
+- [ ] I have signed off the Developer Certificate of Origin (DCO)
+- [ ] I have signed my commit with my GitHub SSH/GPG key (more info [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits))

--- a/arconia-bom/build.gradle
+++ b/arconia-bom/build.gradle
@@ -21,6 +21,7 @@ dependencies {
         api project(":arconia-dev:arconia-dev-services:arconia-dev-services-ollama")
         api project(":arconia-dev:arconia-dev-services:arconia-dev-services-opentelemetry-lgtm")
         api project(":arconia-dev:arconia-dev-services:arconia-dev-services-postgresql")
+        api project(":arconia-dev:arconia-dev-services:arconia-dev-services-mysql")
         api project(":arconia-dev:arconia-dev-services:arconia-dev-services-redis")
 
         api project(":arconia-kubernetes:arconia-kubernetes-service-binding")

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-mysql/build.gradle
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-mysql/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id "code-quality-conventions"
+    id "java-conventions"
+    id "sbom-conventions"
+    id "release-conventions"
+}
+
+dependencies {
+    annotationProcessor "org.springframework.boot:spring-boot-autoconfigure-processor"
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
+    api project(":arconia-dev:arconia-dev-services:arconia-dev-services-core")
+    api "org.springframework.boot:spring-boot-testcontainers"
+    api "org.testcontainers:mysql"
+
+    implementation "org.jspecify:jspecify:${jSpecifyVersion}"
+    implementation "org.springframework.boot:spring-boot-devtools"
+    implementation "org.springframework.boot:spring-boot-starter"
+
+    testImplementation "org.springframework.boot:spring-boot-starter-test"
+    testImplementation "org.springframework.boot:spring-boot-devtools"
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            pom {
+                name = "Arconia Dev Services MySQL"
+                description = "Arconia Dev Services MySQL."
+            }
+        }
+    }
+}

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-mysql/src/main/java/io/arconia/dev/services/mysql/MySqlDevServicesAutoConfiguration.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-mysql/src/main/java/io/arconia/dev/services/mysql/MySqlDevServicesAutoConfiguration.java
@@ -1,0 +1,65 @@
+package io.arconia.dev.services.mysql;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.devtools.restart.RestartScope;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnectionAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.arconia.dev.services.mysql.MySqlDevServicesAutoConfiguration.ConfigurationWithRestart;
+import io.arconia.dev.services.mysql.MySqlDevServicesAutoConfiguration.ConfigurationWithoutRestart;
+
+/**
+ * Auto-configuration for MySQL Dev Services.
+ */
+@AutoConfiguration(before = ServiceConnectionAutoConfiguration.class)
+@ConditionalOnProperty(prefix = MySqlDevServicesProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+@EnableConfigurationProperties(MySqlDevServicesProperties.class)
+@Import({ConfigurationWithRestart.class, ConfigurationWithoutRestart.class})
+public class MySqlDevServicesAutoConfiguration {
+
+    public static final String COMPATIBLE_IMAGE_NAME = "mysql";
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(RestartScope.class)
+    public static class ConfigurationWithRestart {
+
+        @Bean
+        @RestartScope
+        @ServiceConnection
+        @ConditionalOnMissingBean
+        MySQLContainer<?> mysqlContainer(MySqlDevServicesProperties properties) {
+            return new MySQLContainer<>(DockerImageName.parse(properties.getImageName())
+                    .asCompatibleSubstituteFor(COMPATIBLE_IMAGE_NAME))
+                    .withEnv(properties.getEnvironment())
+                    .withReuse(properties.isReusable());
+        }
+
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnMissingClass("org.springframework.boot.devtools.restart.RestartScope")
+    public static class ConfigurationWithoutRestart {
+
+        @Bean
+        @ServiceConnection
+        @ConditionalOnMissingBean
+        MySQLContainer<?> mysqlContainerNoRestartScope(MySqlDevServicesProperties properties) {
+            return new MySQLContainer<>(DockerImageName.parse(properties.getImageName())
+                    .asCompatibleSubstituteFor(COMPATIBLE_IMAGE_NAME))
+                    .withEnv(properties.getEnvironment())
+                    .withReuse(properties.isReusable());
+        }
+
+    }
+
+}

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-mysql/src/main/java/io/arconia/dev/services/mysql/MySqlDevServicesProperties.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-mysql/src/main/java/io/arconia/dev/services/mysql/MySqlDevServicesProperties.java
@@ -1,0 +1,74 @@
+package io.arconia.dev.services.mysql;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import io.arconia.dev.services.core.config.DevServicesProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Properties for the MySQL Dev Services.
+ */
+@ConfigurationProperties(prefix = MySqlDevServicesProperties.CONFIG_PREFIX)
+public class MySqlDevServicesProperties implements DevServicesProperties {
+
+    public static final String CONFIG_PREFIX = "arconia.dev.services.mysql";
+
+    /**
+     * Whether the dev service is enabled.
+     */
+    private boolean enabled = true;
+
+    /**
+     * Full name of the container image used in the dev service.
+     */
+    private String imageName = "mysql:9.3.0";
+
+    /**
+     * Environment variables to set in the container.
+     */
+    private Map<String,String> environment = new HashMap<>();
+
+    /**
+     * Whether the container used in the dev service is reusable across applications.
+     */
+    private boolean reusable = false;
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public String getImageName() {
+        return imageName;
+    }
+
+    public void setImageName(String imageName) {
+        this.imageName = imageName;
+    }
+
+    @Override
+    public Map<String, String> getEnvironment() {
+        return environment;
+    }
+
+    public void setEnvironment(Map<String, String> environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public boolean isReusable() {
+        return reusable;
+    }
+
+    public void setReusable(boolean reusable) {
+        this.reusable = reusable;
+    }
+
+}

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-mysql/src/main/java/io/arconia/dev/services/mysql/package-info.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-mysql/src/main/java/io/arconia/dev/services/mysql/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.arconia.dev.services.mysql;
+
+import org.jspecify.annotations.NullMarked;

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-mysql/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-mysql/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.arconia.dev.services.mysql.MySqlDevServicesAutoConfiguration

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-mysql/src/test/java/io/arconia/dev/services/mysql/MySqlDevServicesAutoConfigurationTests.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-mysql/src/test/java/io/arconia/dev/services/mysql/MySqlDevServicesAutoConfigurationTests.java
@@ -1,0 +1,55 @@
+package io.arconia.dev.services.mysql;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.devtools.restart.RestartScope;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.testcontainers.containers.MySQLContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link MySqlDevServicesAutoConfiguration}.
+ */
+class MySqlDevServicesAutoConfigurationTests {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withClassLoader(new FilteredClassLoader(RestartScope.class))
+            .withConfiguration(AutoConfigurations.of(MySqlDevServicesAutoConfiguration.class));
+
+    @Test
+    void autoConfigurationNotActivatedWhenDisabled() {
+        contextRunner
+            .withPropertyValues("arconia.dev.services.mysql.enabled=false")
+            .run(context -> assertThat(context).doesNotHaveBean(MySQLContainer.class));
+    }
+
+    @Test
+    void mysqlContainerAvailableWithDefaultConfiguration() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(MySQLContainer.class);
+            MySQLContainer<?> container = context.getBean(MySQLContainer.class);
+            assertThat(container.getDockerImageName()).contains("mysql");
+            assertThat(container.isShouldBeReused()).isFalse();
+        });
+    }
+
+    @Test
+    void mysqlContainerConfigurationApplied() {
+        contextRunner
+            .withPropertyValues(
+                "arconia.dev.services.mysql.image-name=docker.io/mysql",
+                "arconia.dev.services.mysql.environment.MYSQL_USER=test",
+                "arconia.dev.services.mysql.reusable=false"
+            )
+            .run(context -> {
+                assertThat(context).hasSingleBean(MySQLContainer.class);
+                MySQLContainer<?> container = context.getBean(MySQLContainer.class);
+                assertThat(container.getDockerImageName()).contains("docker.io/mysql");
+                assertThat(container.getEnv()).contains("MYSQL_USER=test");
+                assertThat(container.isShouldBeReused()).isFalse();
+            });
+    }
+
+}

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-mysql/src/test/java/io/arconia/dev/services/mysql/MySqlDevServicesPropertiesTests.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-mysql/src/test/java/io/arconia/dev/services/mysql/MySqlDevServicesPropertiesTests.java
@@ -1,0 +1,45 @@
+package io.arconia.dev.services.mysql;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link MySqlDevServicesProperties}.
+ */
+class MySqlDevServicesPropertiesTests {
+
+    @Test
+    void shouldHaveCorrectConfigPrefix() {
+        assertThat(MySqlDevServicesProperties.CONFIG_PREFIX)
+                .isEqualTo("arconia.dev.services.mysql");
+    }
+
+    @Test
+    void shouldCreateInstanceWithDefaultValues() {
+        MySqlDevServicesProperties properties = new MySqlDevServicesProperties();
+
+        assertThat(properties.isEnabled()).isTrue();
+        assertThat(properties.getImageName()).isEqualTo("mysql:9.3.0");
+        assertThat(properties.getEnvironment()).isEmpty();
+        assertThat(properties.isReusable()).isFalse();
+    }
+
+    @Test
+    void shouldUpdateValues() {
+        MySqlDevServicesProperties properties = new MySqlDevServicesProperties();
+
+        properties.setEnabled(false);
+        properties.setImageName("mysql:latest");
+        properties.setEnvironment(Map.of("KEY", "value"));
+        properties.setReusable(false);
+
+        assertThat(properties.isEnabled()).isFalse();
+        assertThat(properties.getImageName()).isEqualTo("mysql:latest");
+        assertThat(properties.getEnvironment()).containsEntry("KEY", "value");
+        assertThat(properties.isReusable()).isFalse();
+    }
+
+}

--- a/docs/modules/dev-services/nav.adoc
+++ b/docs/modules/dev-services/nav.adoc
@@ -2,4 +2,5 @@
 * xref:ollama.adoc[Ollama]
 * xref:opentelemetry:dev-services.adoc[OpenTelemetry]
 * xref:postgresql.adoc[PostgreSQL]
+* xref:mysql.adoc[MySQL]
 * xref:redis.adoc[Redis]

--- a/docs/modules/dev-services/pages/index.adoc
+++ b/docs/modules/dev-services/pages/index.adoc
@@ -24,4 +24,5 @@ TIP: For an even better developer experience, you can use the Arconia CLI to run
 * xref:ollama.adoc[Ollama]
 * xref:opentelemetry:dev-services.adoc[OpenTelemetry]
 * xref:postgresql.adoc[PostgreSQL]
+* xref:mysql.adoc[MySQL]
 * xref:redis.adoc[Redis]

--- a/docs/modules/dev-services/pages/mysql.adoc
+++ b/docs/modules/dev-services/pages/mysql.adoc
@@ -1,0 +1,61 @@
+= MySQL Dev Service
+
+When your application needs a relational database (such as when using Spring Data JDBC or Spring Data JPA), you can use the MySQL Dev Service to automatically start a MySQL database. This enables you to develop and test your application without having to manually start and manage a database server.
+
+== Dependencies
+
+First, you need to add the MySQL Dev Service dependency to your project. You can also include the https://docs.spring.io/spring-boot/reference/using/devtools.html[Spring Boot DevTools] dependency to enable live reload of your application during development.
+
+[source,groovy]
+----
+dependencies {
+  developmentOnly "org.springframework.boot:spring-boot-devtools"
+  testAndDevelopmentOnly "io.arconia:arconia-dev-services-mysql"
+}
+----
+
+NOTE: When you use the Spring Boot DevTools in your project, Arconia will keep the Dev Services running while you make changes to your code instead of restarting them with the application. This allows you to see the changes in real-time without having to restart the Dev Services.
+
+== Running the Application
+
+Unlike the lower-level Testcontainers support in Spring Boot, Arconia doesn't require special tasks to run your application when using Dev Services (`./gradlew bootTestRun` or `./mvnw spring-boot:test-run`). You can simply run your application using the usual tasks provided by the Spring Boot plugins for Gradle or Maven.
+
+* Gradle: `./gradlew bootRun`
+* Maven: `./mvnw spring-boot:run`
+
+The Dev Service will automatically start when you run your application.
+
+Your integration tests will automatically use the Dev Services without any additional configuration.
+
+== Customizing the Dev Service
+
+You can customize the Dev Service via configuration properties, such as changing the image name or not reusing the service across multiple applications.
+
+[source,yaml]
+----
+arconia:
+  dev:
+    services:
+      mysql:
+        image-name: mysql:9.3.0-oracle
+        reusable: false
+----
+
+=== Disabling the Dev Service
+
+If you want to disable the Dev Service, you can do so via configuration properties.
+
+[source,yaml]
+----
+arconia:
+  dev:
+    services:
+      mysql:
+        enabled: false
+        environment:
+          MYSQL_USER: test
+----
+
+TIP: You can enable/disable the Dev Service for a specific test class by using the `@TestProperty` annotation or equivalent Spring testing utilities.
+
+TIP: You can enable/disable the Dev Service for a specific application mode (development, test, production), relying on one of the profiles which are automatically configured by Arconia (see xref:../../ROOT/core-features/profiles.adoc[Profiles]).

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,5 +11,5 @@ jSpecifyVersion=1.0.0
 openTelemetryInstrumentationVersion=2.15.0
 openTelemetrySemanticConventionsVersion=1.32.0
 redisTestcontainersVersion=2.2.4
-springAiVersion=1.0.0-M7
+springAiVersion=1.0.0-M8
 springCloudBindingsVersion=2.0.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.arconia
-version=0.10.3
+version=0.10.4-SNAPSHOT
 
 org.gradle.configuration-cache=false
 org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.arconia
-version=0.10.2-SNAPSHOT
+version=0.10.3
 
 org.gradle.configuration-cache=false
 org.gradle.caching=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-rc-3-bin.zip
+distributionSha256Sum=61ad310d3c7d3e5da131b76bbf22b5a4c0786e9d892dae8c1658d4b484de3caa
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,6 +20,7 @@ include 'arconia-dev:arconia-dev-services:arconia-dev-services-core'
 include 'arconia-dev:arconia-dev-services:arconia-dev-services-ollama'
 include 'arconia-dev:arconia-dev-services:arconia-dev-services-opentelemetry-lgtm'
 include 'arconia-dev:arconia-dev-services:arconia-dev-services-postgresql'
+include 'arconia-dev:arconia-dev-services:arconia-dev-services-mysql'
 include 'arconia-dev:arconia-dev-services:arconia-dev-services-redis'
 
 // Kubernetes


### PR DESCRIPTION
## Issue
[Add MySQL Dev Service](https://github.com/arconia-io/arconia/issues/58)

## Description
Added Dev Service support for MySQL database using the latest mysql docker image.

## Checklist

- [x] I have rebased my changes on the latest `main` branch
- [ ] I have squashed my commits into a single commit
- [x] I have added tests to cover my changes
- [x] I have run a build and made sure all tests pass (`./gradlew build`)
- [x] I have added/updated relevant documentation
- [ ] I have signed off the Developer Certificate of Origin (DCO)
- [ ] I have signed my commit with my GitHub SSH/GPG key (more info [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits))
