### PR TITLE
chore(dev): Fix bean names

### DIFF
--- a/arconia-dev/arconia-dev-services/arconia-dev-services-redis/src/main/java/io/arconia/dev/services/redis/RedisDevServicesAutoConfiguration.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-redis/src/main/java/io/arconia/dev/services/redis/RedisDevServicesAutoConfiguration.java
@@ -59,7 +59,7 @@ public class RedisDevServicesAutoConfiguration {
             @Bean
             @ServiceConnection
             @ConditionalOnMissingBean
-            RedisContainer postgresqlContainerNoRestartScope(RedisDevServicesProperties properties) {
+            RedisContainer redisContainerNoRestartScope(RedisDevServicesProperties properties) {
                 return new RedisContainer(DockerImageName.parse(properties.getCommunity().getImageName())
                         .asCompatibleSubstituteFor(COMPATIBLE_IMAGE_NAME))
                         .withEnv(properties.getCommunity().getEnvironment())
@@ -100,7 +100,7 @@ public class RedisDevServicesAutoConfiguration {
             @Bean
             @ServiceConnection
             @ConditionalOnMissingBean
-            RedisStackContainer postgresqlContainerNoRestartScope(RedisDevServicesProperties properties) {
+            RedisStackContainer redisContainerNoRestartScope(RedisDevServicesProperties properties) {
                 return new RedisStackContainer(DockerImageName.parse(properties.getStack().getImageName())
                         .asCompatibleSubstituteFor(COMPATIBLE_IMAGE_NAME))
                         .withEnv(properties.getStack().getEnvironment())


### PR DESCRIPTION
## Description

Redis bean names are named as `postgresqlXXX`, correcting them by updating to `redisXXX`.

Not able to create a Issue as there is no Issue Template matching this kind of refactoring.

## Checklist

- [x] I have reviewed and followed the [contributing guidelines](https://github.com/arconia-io/arconia/blob/main/CONTRIBUTING.md).
- [x] I have run a local build and made sure all tests pass (`./gradlew build`).
- [x] I have signed off the [Developer Certificate of Origin (DCO)](https://github.com/arconia-io/arconia/blob/main/dco.txt).
- [x] I assert that I have read the [Arconia Code of Conduct](https://github.com/arconia-io/arconia/blob/main/CODE_OF_CONDUCT.md) and agree to abide by it.
