### PR TITLE
fix(dev): Add missing Spring AI Testcontainers dependency to MongoDB …

### DIFF
--- a/arconia-dev/arconia-dev-services/arconia-dev-services-mongodb-atlas/build.gradle
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-mongodb-atlas/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
     api project(":arconia-dev:arconia-dev-services:arconia-dev-services-core")
+    api "org.springframework.ai:spring-ai-spring-boot-testcontainers"
     api "org.springframework.boot:spring-boot-testcontainers"
     api "org.testcontainers:mongodb"
 
@@ -20,6 +21,12 @@ dependencies {
     testImplementation "org.springframework.boot:spring-boot-starter-test"
     testImplementation "org.testcontainers:junit-jupiter"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
+    }
 }
 
 publishing {

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-mongodb-atlas/src/main/java/io/arconia/dev/services/mongodb/atlas/MongoDbAtlasDevServicesAutoConfiguration.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-mongodb-atlas/src/main/java/io/arconia/dev/services/mongodb/atlas/MongoDbAtlasDevServicesAutoConfiguration.java
@@ -1,4 +1,4 @@
-package io.arconia.dev.services.mongodb;
+package io.arconia.dev.services.mongodb.atlas;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -15,8 +15,8 @@ import org.springframework.context.annotation.Import;
 import org.testcontainers.mongodb.MongoDBAtlasLocalContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import io.arconia.dev.services.mongodb.MongoDbAtlasDevServicesAutoConfiguration.ConfigurationWithRestart;
-import io.arconia.dev.services.mongodb.MongoDbAtlasDevServicesAutoConfiguration.ConfigurationWithoutRestart;
+import io.arconia.dev.services.mongodb.atlas.MongoDbAtlasDevServicesAutoConfiguration.ConfigurationWithRestart;
+import io.arconia.dev.services.mongodb.atlas.MongoDbAtlasDevServicesAutoConfiguration.ConfigurationWithoutRestart;
 
 /**
  * Autoconfiguration for MongoDB Atlas Dev Services.
@@ -35,9 +35,9 @@ public final class MongoDbAtlasDevServicesAutoConfiguration {
 
         @Bean
         @RestartScope
-        @ServiceConnection
+        @ServiceConnection("mongodb")
         @ConditionalOnMissingBean
-        MongoDBAtlasLocalContainer mongoDBContainer(MongoDbAtlasDevServicesProperties properties) {
+        MongoDBAtlasLocalContainer mongoDBAtlasLocalContainer(MongoDbAtlasDevServicesProperties properties) {
             return new MongoDBAtlasLocalContainer(DockerImageName.parse(properties.getImageName())
                     .asCompatibleSubstituteFor(COMPATIBLE_IMAGE_NAME))
                     .withEnv(properties.getEnvironment())
@@ -52,9 +52,9 @@ public final class MongoDbAtlasDevServicesAutoConfiguration {
     public static final class ConfigurationWithoutRestart {
 
         @Bean
-        @ServiceConnection
+        @ServiceConnection("mongodb")
         @ConditionalOnMissingBean
-        MongoDBAtlasLocalContainer mongoDBContainerNoRestartScope(MongoDbAtlasDevServicesProperties properties) {
+        MongoDBAtlasLocalContainer mongoDBAtlasLocalContainerNoRestartScope(MongoDbAtlasDevServicesProperties properties) {
             return new MongoDBAtlasLocalContainer(DockerImageName.parse(properties.getImageName())
                     .asCompatibleSubstituteFor(COMPATIBLE_IMAGE_NAME))
                     .withEnv(properties.getEnvironment())

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-mongodb-atlas/src/main/java/io/arconia/dev/services/mongodb/atlas/MongoDbAtlasDevServicesProperties.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-mongodb-atlas/src/main/java/io/arconia/dev/services/mongodb/atlas/MongoDbAtlasDevServicesProperties.java
@@ -1,4 +1,4 @@
-package io.arconia.dev.services.mongodb;
+package io.arconia.dev.services.mongodb.atlas;
 
 import java.time.Duration;
 import java.util.HashMap;

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-mongodb-atlas/src/main/java/io/arconia/dev/services/mongodb/atlas/package-info.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-mongodb-atlas/src/main/java/io/arconia/dev/services/mongodb/atlas/package-info.java
@@ -1,4 +1,4 @@
 @NullMarked
-package io.arconia.dev.services.mongodb;
+package io.arconia.dev.services.mongodb.atlas;
 
 import org.jspecify.annotations.NullMarked;

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-mongodb-atlas/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-mongodb-atlas/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,1 @@
-io.arconia.dev.services.mongodb.MongoDbAtlasDevServicesAutoConfiguration
+io.arconia.dev.services.mongodb.atlas.MongoDbAtlasDevServicesAutoConfiguration

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-mongodb-atlas/src/test/java/io/arconia/dev/services/mongodb/atlas/MongoDbAtlasDevServicesAutoConfigurationTests.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-mongodb-atlas/src/test/java/io/arconia/dev/services/mongodb/atlas/MongoDbAtlasDevServicesAutoConfigurationTests.java
@@ -1,4 +1,4 @@
-package io.arconia.dev.services.mongodb;
+package io.arconia.dev.services.mongodb.atlas;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -43,8 +43,8 @@ class MongoDbAtlasDevServicesAutoConfigurationTests {
         contextRunner
             .withPropertyValues(
                 "arconia.dev.services.mongodb-atlas.environment.KEY=value",
-                "arconia.dev.services.mongodb.shared=never",
-                "arconia.dev.services.mongodb.startup-timeout=90s"
+                "arconia.dev.services.mongodb-atlas.shared=never",
+                "arconia.dev.services.mongodb-atlas.startup-timeout=90s"
             )
             .run(context -> {
                 assertThat(context).hasSingleBean(MongoDBAtlasLocalContainer.class);

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-mongodb-atlas/src/test/java/io/arconia/dev/services/mongodb/atlas/MongoDbAtlasDevServicesPropertiesTests.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-mongodb-atlas/src/test/java/io/arconia/dev/services/mongodb/atlas/MongoDbAtlasDevServicesPropertiesTests.java
@@ -1,4 +1,4 @@
-package io.arconia.dev.services.mongodb;
+package io.arconia.dev.services.mongodb.atlas;
 
 import java.time.Duration;
 import java.util.Map;


### PR DESCRIPTION
Hi @ThomasVitale,

- Add missing Spring AI Test Containers dependency to MongoDB Atlas Dev Service
- Included `mongodb` value to `@ServiceConnection` annotation
- Modified beanNames same as classNames
- Refactored the package from `io.arconia.dev.services.mongodb` to `io.arconia.dev.services.mongodb.atlas`

Thanks,
Mahi

Fixes gh-122
 
