### PR TITLE
feat(dev): add Garage S3 dev service

### DIFF
--- a/arconia-bom/build.gradle
+++ b/arconia-bom/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
         api project(":arconia-dev:arconia-dev-services:arconia-dev-services-artemis")
         api project(":arconia-dev:arconia-dev-services:arconia-dev-services-docling")
+        api project(":arconia-dev:arconia-dev-services:arconia-dev-services-garage")
         api project(":arconia-dev:arconia-dev-services:arconia-dev-services-kafka")
         api project(":arconia-dev:arconia-dev-services:arconia-dev-services-lgtm")
         api project(":arconia-dev:arconia-dev-services:arconia-dev-services-lldap")
@@ -65,6 +66,7 @@ dependencies {
         api project(":spring-boot-starters:arconia-opentelemetry-spring-boot-starter")
         api project(":spring-boot-starters:arconia-spring-boot-starter")
 
+        api project(":arconia-testcontainers:arconia-testcontainers-garage")
         api project(":arconia-testcontainers:arconia-testcontainers-phoenix")
         api project(":arconia-testcontainers:arconia-testcontainers-redis")
         api project(":arconia-testcontainers:arconia-testcontainers-valkey")

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/build.gradle
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/build.gradle
@@ -1,0 +1,45 @@
+plugins {
+    id "code-quality-conventions"
+    id "java-conventions"
+    id "sbom-conventions"
+    id "release-conventions"
+}
+
+dependencies {
+    annotationProcessor "org.springframework.boot:spring-boot-autoconfigure-processor"
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
+    api project(":arconia-dev:arconia-dev-services:arconia-dev-services-core")
+    api project(":arconia-testcontainers:arconia-testcontainers-garage")
+    api "org.springframework.boot:spring-boot-starter"
+    api "org.springframework.boot:spring-boot-testcontainers"
+
+    optional "io.awspring.cloud:spring-cloud-aws-autoconfigure"
+    optional "io.awspring.cloud:spring-cloud-aws-s3"
+    optional "org.springframework.boot:spring-boot-devtools"
+
+    testImplementation project(":arconia-dev:arconia-dev-services:arconia-dev-services-tests")
+    testImplementation "io.awspring.cloud:spring-cloud-aws-autoconfigure"
+    testImplementation "io.awspring.cloud:spring-cloud-aws-s3"
+    testImplementation "io.awspring.cloud:spring-cloud-aws-starter-s3"
+    testImplementation "org.springframework.boot:spring-boot-starter-test"
+    testImplementation "org.testcontainers:testcontainers-junit-jupiter"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "io.awspring.cloud:spring-cloud-aws-dependencies:${springCloudAwsVersion}"
+    }
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            pom {
+                name = "Arconia Dev Services Garage"
+                description = "Arconia Dev Services Garage."
+            }
+        }
+    }
+}

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/build.gradle
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/build.gradle
@@ -38,7 +38,7 @@ publishing {
         mavenJava(MavenPublication) {
             pom {
                 name = "Arconia Dev Services Garage"
-                description = "Arconia Dev Services Garage."
+                description = "Auto-configuration for Garage as an Arconia Dev Service."
             }
         }
     }

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/ArconiaGarageContainer.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/ArconiaGarageContainer.java
@@ -1,0 +1,35 @@
+package io.arconia.dev.services.garage;
+
+import org.testcontainers.utility.DockerImageName;
+
+import io.arconia.dev.services.core.container.ContainerConfigurer;
+import io.arconia.dev.services.core.util.ContainerUtils;
+import io.arconia.testcontainers.garage.GarageContainer;
+
+/**
+ * A {@link GarageContainer} configured for use with Arconia Dev Services.
+ */
+final class ArconiaGarageContainer extends GarageContainer {
+
+    private final GarageDevServicesProperties properties;
+
+    static final String COMPATIBLE_IMAGE_NAME = "dxflrs/garage";
+
+    ArconiaGarageContainer(GarageDevServicesProperties properties) {
+        super(DockerImageName.parse(properties.getImageName()).asCompatibleSubstituteFor(COMPATIBLE_IMAGE_NAME));
+        this.properties = properties;
+
+        withDefaultBucket(properties.getBucketName());
+
+        ContainerConfigurer.base(this, properties);
+    }
+
+    @Override
+    protected void configure() {
+        super.configure();
+        if (ContainerUtils.isValidPort(properties.getPort())) {
+            addFixedExposedPort(properties.getPort(), S3_API_PORT);
+        }
+    }
+
+}

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/GarageContainerConnectionDetailsFactory.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/GarageContainerConnectionDetailsFactory.java
@@ -34,7 +34,7 @@ class GarageContainerConnectionDetailsFactory
 
         @Override
         public URI getEndpoint() {
-            return URI.create(getContainer().getS3Endpoint());
+            return getContainer().getS3EndpointUri();
         }
 
         @Override

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/GarageContainerConnectionDetailsFactory.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/GarageContainerConnectionDetailsFactory.java
@@ -1,0 +1,56 @@
+package io.arconia.dev.services.garage;
+
+import java.net.URI;
+
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionDetailsFactory;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionSource;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+
+import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
+
+import io.arconia.testcontainers.garage.GarageContainer;
+
+/**
+ * {@link ContainerConnectionDetailsFactory} producing {@link AwsConnectionDetails} from a
+ * {@link ServiceConnection @ServiceConnection}-annotated {@link GarageContainer}.
+ *
+ * <p>Mirrors {@code AwsContainerConnectionDetailsFactory} from Spring Cloud AWS, which does
+ * the same for LocalStack. Loaded only when Spring Cloud AWS is on the classpath.
+ */
+class GarageContainerConnectionDetailsFactory
+        extends ContainerConnectionDetailsFactory<GarageContainer, AwsConnectionDetails> {
+
+    @Override
+    protected AwsConnectionDetails getContainerConnectionDetails(ContainerConnectionSource<GarageContainer> source) {
+        return new GarageAwsConnectionDetails(source);
+    }
+
+    private static final class GarageAwsConnectionDetails
+            extends ContainerConnectionDetails<GarageContainer> implements AwsConnectionDetails {
+
+        GarageAwsConnectionDetails(ContainerConnectionSource<GarageContainer> source) {
+            super(source);
+        }
+
+        @Override
+        public URI getEndpoint() {
+            return URI.create(getContainer().getS3Endpoint());
+        }
+
+        @Override
+        public String getRegion() {
+            return getContainer().getRegion();
+        }
+
+        @Override
+        public String getAccessKey() {
+            return getContainer().getAccessKey();
+        }
+
+        @Override
+        public String getSecretKey() {
+            return getContainer().getSecretKey();
+        }
+    }
+
+}

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/GarageDevServicesAutoConfiguration.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/GarageDevServicesAutoConfiguration.java
@@ -1,0 +1,44 @@
+package io.arconia.dev.services.garage;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnectionAutoConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
+
+import io.arconia.dev.services.core.autoconfigure.ConditionalOnDevServicesEnabled;
+import io.arconia.dev.services.core.autoconfigure.DevServicesAutoConfiguration;
+import io.arconia.dev.services.core.registration.DevServicesRegistrar;
+import io.arconia.dev.services.core.registration.DevServicesRegistry;
+import io.arconia.dev.services.garage.GarageDevServicesAutoConfiguration.GarageDevServicesRegistrar;
+
+/**
+ * Auto-configuration for Garage Dev Services.
+ */
+@AutoConfiguration(after = DevServicesAutoConfiguration.class, before = ServiceConnectionAutoConfiguration.class)
+@ConditionalOnDevServicesEnabled("garage")
+@EnableConfigurationProperties(GarageDevServicesProperties.class)
+@Import(GarageDevServicesRegistrar.class)
+public final class GarageDevServicesAutoConfiguration {
+
+    private GarageDevServicesAutoConfiguration() {}
+
+    static class GarageDevServicesRegistrar extends DevServicesRegistrar {
+
+        @Override
+        protected void registerDevServices(DevServicesRegistry registry, Environment environment) {
+            var properties = bindProperties(GarageDevServicesProperties.CONFIG_PREFIX, GarageDevServicesProperties.class);
+
+            registry.registerDevService(service -> service
+                    .name("garage")
+                    .description("Garage Dev Service")
+                    .container(container -> container
+                            .type(ArconiaGarageContainer.class)
+                            .serviceConnectionName("garage")
+                            .supplier(() -> new ArconiaGarageContainer(properties))
+                    ));
+        }
+
+    }
+
+}

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/GarageDevServicesProperties.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/GarageDevServicesProperties.java
@@ -1,0 +1,179 @@
+package io.arconia.dev.services.garage;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import io.arconia.dev.services.api.config.BaseDevServicesProperties;
+import io.arconia.dev.services.api.config.ResourceMapping;
+import io.arconia.dev.services.api.config.VolumeMapping;
+import io.arconia.testcontainers.garage.GarageContainer;
+
+/**
+ * Properties for the Garage Dev Services.
+ */
+@ConfigurationProperties(prefix = GarageDevServicesProperties.CONFIG_PREFIX)
+public class GarageDevServicesProperties implements BaseDevServicesProperties {
+
+    public static final String CONFIG_PREFIX = "arconia.dev.services.garage";
+
+    /**
+     * Whether the dev service is enabled.
+     */
+    private boolean enabled = true;
+
+    /**
+     * Full name of the container image used in the dev service.
+     */
+    private String imageName = "dxflrs/garage:v2.3.0";
+
+    /**
+     * Environment variables to set in the service.
+     */
+    private Map<String, String> environment = new HashMap<>();
+
+    /**
+     * Network aliases to assign to the dev service container.
+     */
+    private List<String> networkAliases = new ArrayList<>();
+
+    /**
+     * Fixed port for exposing the Garage S3 API port to the host.
+     * When it's 0 (default), a random available port is assigned dynamically.
+     */
+    private int port = 0;
+
+    /**
+     * Resources from the classpath or host filesystem to copy into the container.
+     * They can be files or directories that will be copied to the specified
+     * destination path inside the container at startup and are immutable (read-only).
+     */
+    private List<ResourceMapping> resources = new ArrayList<>();
+
+    /**
+     * Whether the dev service is shared among applications.
+     * Only applicable in dev mode.
+     */
+    private boolean shared = false;
+
+    /**
+     * Maximum waiting time for the service to start.
+     */
+    private Duration startupTimeout = Duration.ofSeconds(60);
+
+    /**
+     * Files or directories to mount from the host filesystem into the container.
+     * They are mounted at the specified destination path inside the container
+     * at startup and are mutable (read-write). Changes in either the host
+     * or the container will be immediately reflected in the other.
+     */
+    private List<VolumeMapping> volumes = new ArrayList<>();
+
+    /**
+     * Name of the bucket created automatically when the container starts.
+     */
+    private String bucketName = GarageContainer.DEFAULT_BUCKET;
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public String getImageName() {
+        return imageName;
+    }
+
+    @Override
+    public void setImageName(String imageName) {
+        this.imageName = imageName;
+    }
+
+    @Override
+    public Map<String, String> getEnvironment() {
+        return environment;
+    }
+
+    @Override
+    public void setEnvironment(Map<String, String> environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public List<String> getNetworkAliases() {
+        return networkAliases;
+    }
+
+    @Override
+    public void setNetworkAliases(List<String> networkAliases) {
+        this.networkAliases = networkAliases;
+    }
+
+    @Override
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    @Override
+    public List<ResourceMapping> getResources() {
+        return resources;
+    }
+
+    @Override
+    public void setResources(List<ResourceMapping> resources) {
+        this.resources = resources;
+    }
+
+    @Override
+    public boolean isShared() {
+        return shared;
+    }
+
+    @Override
+    public void setShared(boolean shared) {
+        this.shared = shared;
+    }
+
+    @Override
+    public Duration getStartupTimeout() {
+        return startupTimeout;
+    }
+
+    @Override
+    public void setStartupTimeout(Duration startupTimeout) {
+        this.startupTimeout = startupTimeout;
+    }
+
+    @Override
+    public List<VolumeMapping> getVolumes() {
+        return volumes;
+    }
+
+    @Override
+    public void setVolumes(List<VolumeMapping> volumes) {
+        this.volumes = volumes;
+    }
+
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    public void setBucketName(String bucketName) {
+        this.bucketName = bucketName;
+    }
+
+}

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/GarageDevServicesProperties.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/GarageDevServicesProperties.java
@@ -29,7 +29,7 @@ public class GarageDevServicesProperties implements BaseDevServicesProperties {
     /**
      * Full name of the container image used in the dev service.
      */
-    private String imageName = "dxflrs/garage:v2.3.0";
+    private String imageName = GarageContainer.DEFAULT_IMAGE;
 
     /**
      * Environment variables to set in the service.

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/GarageSpringCloudAwsDevServicesAutoConfiguration.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/GarageSpringCloudAwsDevServicesAutoConfiguration.java
@@ -1,0 +1,42 @@
+package io.arconia.dev.services.garage;
+
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
+
+import io.arconia.dev.services.core.autoconfigure.ConditionalOnDevServicesEnabled;
+import io.arconia.dev.services.core.registration.DevServicesRegistrar;
+import io.arconia.dev.services.core.registration.DevServicesRegistry;
+import io.arconia.dev.services.garage.GarageSpringCloudAwsDevServicesAutoConfiguration.GarageSpringCloudAwsDefaultsRegistrar;
+
+/**
+ * Auto-configuration that contributes Spring Cloud AWS S3 defaults required by Garage —
+ * specifically path-style addressing, which is mandatory for S3-compatible stores like Garage
+ * but is not part of {@code AwsConnectionDetails}.
+ *
+ * <p>The endpoint, region, and credentials are provided through the
+ * {@link GarageContainerConnectionDetailsFactory} via {@code AwsConnectionDetails}.
+ */
+@AutoConfiguration(after = GarageDevServicesAutoConfiguration.class)
+@ConditionalOnDevServicesEnabled("garage")
+@ConditionalOnClass(name = "io.awspring.cloud.autoconfigure.s3.properties.S3Properties")
+@Import(GarageSpringCloudAwsDefaultsRegistrar.class)
+public final class GarageSpringCloudAwsDevServicesAutoConfiguration {
+
+    private GarageSpringCloudAwsDevServicesAutoConfiguration() {}
+
+    static class GarageSpringCloudAwsDefaultsRegistrar extends DevServicesRegistrar {
+
+        @Override
+        protected void registerDevServices(DevServicesRegistry registry, Environment environment) {
+            setDefaultProperties(Map.of(
+                    "spring.cloud.aws.s3.path-style-access-enabled", "true"
+            ));
+        }
+
+    }
+
+}

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/GarageSpringCloudAwsDevServicesAutoConfiguration.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/GarageSpringCloudAwsDevServicesAutoConfiguration.java
@@ -20,6 +20,14 @@ import io.arconia.dev.services.garage.GarageSpringCloudAwsDevServicesAutoConfigu
  * <p>The endpoint, region, and credentials are provided through the
  * {@link GarageContainerConnectionDetailsFactory} via {@code AwsConnectionDetails}.
  */
+/**
+ * Auto-configuration that contributes Spring Cloud AWS S3 defaults required by Garage —
+ * specifically path-style addressing, which is mandatory for S3-compatible stores like Garage
+ * but is not part of {@code AwsConnectionDetails}.
+ *
+ * <p>The endpoint, region, and credentials are provided through the
+ * {@link GarageContainerConnectionDetailsFactory} via {@code AwsConnectionDetails}.
+ */
 @AutoConfiguration(after = GarageDevServicesAutoConfiguration.class)
 @ConditionalOnDevServicesEnabled("garage")
 @ConditionalOnClass(name = "io.awspring.cloud.autoconfigure.s3.properties.S3Properties")

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/package-info.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/java/io/arconia/dev/services/garage/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.arconia.dev.services.garage;
+
+import org.jspecify.annotations.NullMarked;

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/resources/META-INF/spring.factories
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.service.connection.ConnectionDetailsFactory=\
+io.arconia.dev.services.garage.GarageContainerConnectionDetailsFactory

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+io.arconia.dev.services.garage.GarageDevServicesAutoConfiguration
+io.arconia.dev.services.garage.GarageSpringCloudAwsDevServicesAutoConfiguration

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/test/java/io/arconia/dev/services/garage/ArconiaGarageContainerTests.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/test/java/io/arconia/dev/services/garage/ArconiaGarageContainerTests.java
@@ -27,7 +27,6 @@ class ArconiaGarageContainerTests {
         container.configure();
 
         var portBindings = container.getPortBindings();
-        assertThat(portBindings).isNotNull();
         assertThat(portBindings)
                 .anyMatch(binding -> binding.startsWith(
                         properties.getPort() + ":" + GarageContainer.S3_API_PORT));

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/test/java/io/arconia/dev/services/garage/ArconiaGarageContainerTests.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/test/java/io/arconia/dev/services/garage/ArconiaGarageContainerTests.java
@@ -1,0 +1,46 @@
+package io.arconia.dev.services.garage;
+
+import org.junit.jupiter.api.Test;
+
+import io.arconia.testcontainers.garage.GarageContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ArconiaGarageContainer}.
+ */
+class ArconiaGarageContainerTests {
+
+    @Test
+    void whenExposedPortsAreNotConfigured() {
+        var container = new ArconiaGarageContainer(new GarageDevServicesProperties());
+        container.configure();
+        assertThat(container.getPortBindings()).isEmpty();
+    }
+
+    @Test
+    void whenExposedPortsAreConfigured() {
+        var properties = new GarageDevServicesProperties();
+        properties.setPort(13900);
+
+        var container = new ArconiaGarageContainer(properties);
+        container.configure();
+
+        var portBindings = container.getPortBindings();
+        assertThat(portBindings).isNotNull();
+        assertThat(portBindings)
+                .anyMatch(binding -> binding.startsWith(
+                        properties.getPort() + ":" + GarageContainer.S3_API_PORT));
+    }
+
+    @Test
+    void whenBucketNameOverridden() {
+        var properties = new GarageDevServicesProperties();
+        properties.setBucketName("custom-bucket");
+
+        var container = new ArconiaGarageContainer(properties);
+
+        assertThat(container.getDefaultBucket()).isEqualTo("custom-bucket");
+    }
+
+}

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/test/java/io/arconia/dev/services/garage/GarageDevServicesAutoConfigurationIT.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/test/java/io/arconia/dev/services/garage/GarageDevServicesAutoConfigurationIT.java
@@ -1,0 +1,100 @@
+package io.arconia.dev.services.garage;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.devtools.restart.RestartScope;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnectionAutoConfiguration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.EnabledIfDockerAvailable;
+
+import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
+
+import io.arconia.dev.services.tests.BaseDevServicesAutoConfigurationIT;
+import io.arconia.testcontainers.garage.GarageContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link GarageDevServicesAutoConfiguration}.
+ */
+@EnabledIfDockerAvailable
+class GarageDevServicesAutoConfigurationIT extends BaseDevServicesAutoConfigurationIT {
+
+    private final ApplicationContextRunner contextRunner = defaultContextRunner(GarageDevServicesAutoConfiguration.class);
+
+    @Override
+    protected ApplicationContextRunner getContextRunner() {
+        return contextRunner;
+    }
+
+    @Override
+    protected Class<?> getAutoConfigurationClass() {
+        return GarageDevServicesAutoConfiguration.class;
+    }
+
+    @Override
+    protected Class<? extends GenericContainer<?>> getContainerClass() {
+        return GarageContainer.class;
+    }
+
+    @Override
+    protected String getServiceName() {
+        return "garage";
+    }
+
+    @Test
+    void containerAvailableWithDefaultConfiguration() {
+        getContextRunner()
+                .run(context -> {
+                    assertThat(context).hasSingleBean(getContainerClass());
+                    var container = context.getBean(getContainerClass());
+                    assertThat(container.getDockerImageName()).contains(ArconiaGarageContainer.COMPATIBLE_IMAGE_NAME);
+                    assertThat(container.getNetworkAliases()).hasSize(1);
+                    assertThat(container.isShouldBeReused()).isFalse();
+
+                    assertThatHasSingletonScope(context);
+                });
+    }
+
+    @Test
+    void containerConfigurationApplied() {
+        String[] properties = ArrayUtils.addAll(commonConfigurationProperties());
+
+        getContextRunner()
+                .withPropertyValues(properties)
+                .run(context -> {
+                    var container = context.getBean(getContainerClass());
+                    container.start();
+                    assertThatConfigurationIsApplied(container);
+                    container.stop();
+                });
+    }
+
+    @Test
+    void awsConnectionDetailsBeanProvidedFromRunningContainer() {
+        new ApplicationContextRunner()
+                .withClassLoader(new FilteredClassLoader(RestartScope.class))
+                .withConfiguration(AutoConfigurations.of(
+                        GarageDevServicesAutoConfiguration.class,
+                        ServiceConnectionAutoConfiguration.class))
+                .run(context -> {
+                    var container = context.getBean(getContainerClass());
+                    container.start();
+                    try {
+                        assertThat(context).hasSingleBean(AwsConnectionDetails.class);
+                        var details = context.getBean(AwsConnectionDetails.class);
+                        assertThat(details.getEndpoint()).isNotNull();
+                        assertThat(details.getEndpoint().toString()).startsWith("http://");
+                        assertThat(details.getRegion()).isEqualTo(GarageContainer.DEFAULT_REGION);
+                        assertThat(details.getAccessKey()).isEqualTo(GarageContainer.DEFAULT_ACCESS_KEY);
+                        assertThat(details.getSecretKey()).isEqualTo(GarageContainer.DEFAULT_SECRET_KEY);
+                    } finally {
+                        container.stop();
+                    }
+                });
+    }
+
+}

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/test/java/io/arconia/dev/services/garage/GarageDevServicesPropertiesTests.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/test/java/io/arconia/dev/services/garage/GarageDevServicesPropertiesTests.java
@@ -1,0 +1,43 @@
+package io.arconia.dev.services.garage;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import io.arconia.dev.services.tests.BaseDevServicesPropertiesTests;
+import io.arconia.testcontainers.garage.GarageContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link GarageDevServicesProperties}.
+ */
+class GarageDevServicesPropertiesTests extends BaseDevServicesPropertiesTests<GarageDevServicesProperties> {
+
+    @Override
+    protected GarageDevServicesProperties createProperties() {
+        return new GarageDevServicesProperties();
+    }
+
+    @Override
+    protected DefaultValues getExpectedDefaults() {
+        return DefaultValues.builder()
+                .imageName(ArconiaGarageContainer.COMPATIBLE_IMAGE_NAME)
+                .startupTimeout(Duration.ofSeconds(60))
+                .build();
+    }
+
+    @Test
+    void bucketNameDefaultsToContainerDefault() {
+        var properties = new GarageDevServicesProperties();
+        assertThat(properties.getBucketName()).isEqualTo(GarageContainer.DEFAULT_BUCKET);
+    }
+
+    @Test
+    void bucketNameCanBeChanged() {
+        var properties = new GarageDevServicesProperties();
+        properties.setBucketName("my-bucket");
+        assertThat(properties.getBucketName()).isEqualTo("my-bucket");
+    }
+
+}

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/test/java/io/arconia/dev/services/garage/GarageSpringCloudAwsDevServicesAutoConfigurationTests.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-garage/src/test/java/io/arconia/dev/services/garage/GarageSpringCloudAwsDevServicesAutoConfigurationTests.java
@@ -1,0 +1,49 @@
+package io.arconia.dev.services.garage;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.devtools.restart.RestartScope;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link GarageSpringCloudAwsDevServicesAutoConfiguration}.
+ */
+class GarageSpringCloudAwsDevServicesAutoConfigurationTests {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withClassLoader(new FilteredClassLoader(RestartScope.class))
+            .withConfiguration(AutoConfigurations.of(
+                    GarageDevServicesAutoConfiguration.class,
+                    GarageSpringCloudAwsDevServicesAutoConfiguration.class));
+
+    @Test
+    void pathStyleAccessDefaultedWhenSpringCloudAwsOnClasspath() {
+        contextRunner.run(context -> assertThat(context.getEnvironment()
+                .getProperty("spring.cloud.aws.s3.path-style-access-enabled"))
+                .isEqualTo("true"));
+    }
+
+    @Test
+    void pathStyleAccessOverridableByUser() {
+        contextRunner
+                .withPropertyValues("spring.cloud.aws.s3.path-style-access-enabled=false")
+                .run(context -> assertThat(context.getEnvironment()
+                        .getProperty("spring.cloud.aws.s3.path-style-access-enabled"))
+                        .isEqualTo("false"));
+    }
+
+    @Test
+    void autoConfigurationAbsentWhenSpringCloudAwsMissing() {
+        new ApplicationContextRunner()
+                .withClassLoader(new FilteredClassLoader(RestartScope.class, io.awspring.cloud.autoconfigure.s3.properties.S3Properties.class))
+                .withConfiguration(AutoConfigurations.of(
+                        GarageDevServicesAutoConfiguration.class,
+                        GarageSpringCloudAwsDevServicesAutoConfiguration.class))
+                .run(context -> assertThat(context).doesNotHaveBean(
+                        GarageSpringCloudAwsDevServicesAutoConfiguration.class));
+    }
+
+}

--- a/arconia-testcontainers/arconia-testcontainers-garage/build.gradle
+++ b/arconia-testcontainers/arconia-testcontainers-garage/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id "code-quality-conventions"
+    id "java-conventions"
+    id "sbom-conventions"
+    id "release-conventions"
+}
+
+dependencies {
+    api "org.jspecify:jspecify"
+    api "org.testcontainers:testcontainers-junit-jupiter"
+
+    testImplementation "org.springframework.boot:spring-boot-starter-test"
+    testImplementation "software.amazon.awssdk:s3"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "software.amazon.awssdk:bom:${awsSdkVersion}"
+    }
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            pom {
+                name = "Testcontainers Garage"
+                description = "Testcontainers Garage."
+            }
+        }
+    }
+}

--- a/arconia-testcontainers/arconia-testcontainers-garage/src/main/java/io/arconia/testcontainers/garage/GarageContainer.java
+++ b/arconia-testcontainers/arconia-testcontainers-garage/src/main/java/io/arconia/testcontainers/garage/GarageContainer.java
@@ -1,5 +1,7 @@
 package io.arconia.testcontainers.garage;
 
+import java.net.URI;
+
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
@@ -24,8 +26,12 @@ public class GarageContainer extends GenericContainer<GarageContainer> {
     public static final int S3_WEB_PORT = 3902;
     public static final int ADMIN_PORT = 3903;
 
+    public static final String DEFAULT_IMAGE = "dxflrs/garage:v2.3.0";
+
     public static final String DEFAULT_REGION = "garage";
+    @SuppressWarnings("java:S6419")
     public static final String DEFAULT_ACCESS_KEY = "GK00000000000000000000000a";
+    @SuppressWarnings("java:S6419")
     public static final String DEFAULT_SECRET_KEY =
             "0000000000000000000000000000000000000000000000000000000000000000";
     public static final String DEFAULT_BUCKET = "arconia";
@@ -97,10 +103,14 @@ public class GarageContainer extends GenericContainer<GarageContainer> {
     private ExecResult exec(String... command) throws Exception {
         var result = execInContainer(command);
         if (result.getExitCode() != 0) {
+            // Truncate to first 3 tokens to avoid leaking credential arguments (e.g. key import).
+            String display = command.length > 3
+                    ? command[0] + " " + command[1] + " " + command[2] + " ..."
+                    : String.join(" ", command);
             throw new IllegalStateException(
                     "Garage command failed (exit %d): %s%nstdout: %s%nstderr: %s".formatted(
                             result.getExitCode(),
-                            String.join(" ", command),
+                            display,
                             result.getStdout(),
                             result.getStderr()));
         }
@@ -142,6 +152,10 @@ public class GarageContainer extends GenericContainer<GarageContainer> {
 
     public String getS3Endpoint() {
         return "http://" + getHost() + ":" + getMappedPort(S3_API_PORT);
+    }
+
+    public URI getS3EndpointUri() {
+        return URI.create(getS3Endpoint());
     }
 
     public Integer getS3Port() {

--- a/arconia-testcontainers/arconia-testcontainers-garage/src/main/java/io/arconia/testcontainers/garage/GarageContainer.java
+++ b/arconia-testcontainers/arconia-testcontainers-garage/src/main/java/io/arconia/testcontainers/garage/GarageContainer.java
@@ -1,0 +1,167 @@
+package io.arconia.testcontainers.garage;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * A {@link Container} for Garage, an S3-compatible object store.
+ *
+ * <p>Garage requires post-startup initialization (cluster layout, key import, bucket creation)
+ * before its S3 API is usable. The container performs that bootstrap automatically the first
+ * time it starts and exposes deterministic credentials so that consumers can configure their
+ * S3 clients statically.
+ */
+public class GarageContainer extends GenericContainer<GarageContainer> {
+
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("dxflrs/garage");
+
+    public static final int S3_API_PORT = 3900;
+    public static final int RPC_PORT = 3901;
+    public static final int S3_WEB_PORT = 3902;
+    public static final int ADMIN_PORT = 3903;
+
+    public static final String DEFAULT_REGION = "garage";
+    public static final String DEFAULT_ACCESS_KEY = "GK00000000000000000000000a";
+    public static final String DEFAULT_SECRET_KEY =
+            "0000000000000000000000000000000000000000000000000000000000000000";
+    public static final String DEFAULT_BUCKET = "arconia";
+
+    private static final String GARAGE_CONFIG_PATH = "/etc/garage.toml";
+    private static final String KEY_NAME = "arconia-key";
+
+    // Intentional static fixtures for container config — not real secrets.
+    // rpc_secret and admin_token must be valid hex strings of the right length.
+    @SuppressWarnings("java:S6419")
+    private static final String RPC_SECRET =
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    @SuppressWarnings("java:S6419")
+    private static final String ADMIN_TOKEN =
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+    private String accessKey = DEFAULT_ACCESS_KEY;
+    private String secretKey = DEFAULT_SECRET_KEY;
+    private String defaultBucket = DEFAULT_BUCKET;
+
+    public GarageContainer(DockerImageName dockerImageName) {
+        super(dockerImageName);
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        addExposedPorts(S3_API_PORT, S3_WEB_PORT, ADMIN_PORT);
+        // Garage logs this line once the S3 API is listening; image has no shell so a
+        // command-based wait strategy isn't viable.
+        waitingFor(Wait.forLogMessage(".*S3 API server listening on .*\\n", 1));
+    }
+
+    public GarageContainer withCredentials(String accessKey, String secretKey) {
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        return self();
+    }
+
+    public GarageContainer withDefaultBucket(String bucket) {
+        this.defaultBucket = bucket;
+        return self();
+    }
+
+    @Override
+    protected void configure() {
+        super.configure();
+        withCopyToContainer(Transferable.of(buildGarageConfig()), GARAGE_CONFIG_PATH);
+    }
+
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        super.containerIsStarted(containerInfo);
+        bootstrap();
+    }
+
+    private void bootstrap() {
+        try {
+            String nodeId = exec("/garage", "node", "id", "-q").stdout().trim().split("@")[0];
+
+            exec("/garage", "layout", "assign", "-z", "dc1", "-c", "1G", nodeId);
+            exec("/garage", "layout", "apply", "--version", "1");
+
+            exec("/garage", "key", "import", "--yes", "-n", KEY_NAME, accessKey, secretKey);
+            exec("/garage", "bucket", "create", defaultBucket);
+            exec("/garage", "bucket", "allow", "--read", "--write", "--owner",
+                    "--key", KEY_NAME, defaultBucket);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to bootstrap Garage container", ex);
+        }
+    }
+
+    private ExecResult exec(String... command) throws Exception {
+        var result = execInContainer(command);
+        if (result.getExitCode() != 0) {
+            throw new IllegalStateException(
+                    "Garage command failed (exit %d): %s%nstdout: %s%nstderr: %s".formatted(
+                            result.getExitCode(),
+                            String.join(" ", command),
+                            result.getStdout(),
+                            result.getStderr()));
+        }
+        return new ExecResult(result.getStdout(), result.getStderr());
+    }
+
+    private record ExecResult(String stdout, String stderr) {}
+
+    private static String buildGarageConfig() {
+        return """
+                metadata_dir = "/var/lib/garage/meta"
+                data_dir = "/var/lib/garage/data"
+
+                replication_factor = 1
+
+                rpc_bind_addr = "[::]:%d"
+                rpc_public_addr = "127.0.0.1:%d"
+                rpc_secret = "%s"
+
+                [s3_api]
+                s3_region = "%s"
+                api_bind_addr = "[::]:%d"
+                root_domain = ".s3.garage"
+
+                [s3_web]
+                bind_addr = "[::]:%d"
+                root_domain = ".web.garage"
+                index = "index.html"
+
+                [admin]
+                api_bind_addr = "[::]:%d"
+                admin_token = "%s"
+                """.formatted(
+                        RPC_PORT, RPC_PORT, RPC_SECRET,
+                        DEFAULT_REGION, S3_API_PORT,
+                        S3_WEB_PORT,
+                        ADMIN_PORT, ADMIN_TOKEN);
+    }
+
+    public String getS3Endpoint() {
+        return "http://" + getHost() + ":" + getMappedPort(S3_API_PORT);
+    }
+
+    public Integer getS3Port() {
+        return getMappedPort(S3_API_PORT);
+    }
+
+    public String getRegion() {
+        return DEFAULT_REGION;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public String getDefaultBucket() {
+        return defaultBucket;
+    }
+
+}

--- a/arconia-testcontainers/arconia-testcontainers-garage/src/main/java/io/arconia/testcontainers/garage/package-info.java
+++ b/arconia-testcontainers/arconia-testcontainers-garage/src/main/java/io/arconia/testcontainers/garage/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.arconia.testcontainers.garage;
+
+import org.jspecify.annotations.NullMarked;

--- a/arconia-testcontainers/arconia-testcontainers-garage/src/test/java/io/arconia/testcontainers/garage/GarageContainerIT.java
+++ b/arconia-testcontainers/arconia-testcontainers-garage/src/test/java/io/arconia/testcontainers/garage/GarageContainerIT.java
@@ -24,15 +24,36 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfDockerAvailable
 class GarageContainerIT {
 
-    private static final DockerImageName IMAGE = DockerImageName.parse("dxflrs/garage:v2.3.0");
+    private static final DockerImageName IMAGE = DockerImageName.parse(GarageContainer.DEFAULT_IMAGE);
 
     @Test
     void containerStartsAndStopsSuccessfully() {
         try (var container = new GarageContainer(IMAGE)) {
             container.start();
-            assertThat(container.getCurrentContainerInfo().getState().getStatus())
-                    .isEqualTo("running");
-            container.stop();
+            assertThat(container.getS3Endpoint()).startsWith("http://");
+            assertThat(container.getS3Port()).isPositive();
+        }
+    }
+
+    @Test
+    void customCredentialsAcceptedByS3Api() {
+        var customKey = "GK11111111111111111111111a";
+        var customSecret = "1111111111111111111111111111111111111111111111111111111111111111";
+
+        try (var container = new GarageContainer(IMAGE).withCredentials(customKey, customSecret)) {
+            container.start();
+            assertThat(container.getAccessKey()).isEqualTo(customKey);
+            assertThat(container.getSecretKey()).isEqualTo(customSecret);
+
+            try (var s3 = buildClient(container)) {
+                var key = "custom-creds.txt";
+                var body = "custom credentials work";
+                s3.putObject(PutObjectRequest.builder().bucket(container.getDefaultBucket()).key(key).build(),
+                        RequestBody.fromString(body));
+                var fetched = s3.getObjectAsBytes(GetObjectRequest.builder()
+                        .bucket(container.getDefaultBucket()).key(key).build());
+                assertThat(fetched.asString(StandardCharsets.UTF_8)).isEqualTo(body);
+            }
         }
     }
 

--- a/arconia-testcontainers/arconia-testcontainers-garage/src/test/java/io/arconia/testcontainers/garage/GarageContainerIT.java
+++ b/arconia-testcontainers/arconia-testcontainers-garage/src/test/java/io/arconia/testcontainers/garage/GarageContainerIT.java
@@ -1,0 +1,77 @@
+package io.arconia.testcontainers.garage;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.EnabledIfDockerAvailable;
+import org.testcontainers.utility.DockerImageName;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link GarageContainer}.
+ */
+@EnabledIfDockerAvailable
+class GarageContainerIT {
+
+    private static final DockerImageName IMAGE = DockerImageName.parse("dxflrs/garage:v2.3.0");
+
+    @Test
+    void containerStartsAndStopsSuccessfully() {
+        try (var container = new GarageContainer(IMAGE)) {
+            container.start();
+            assertThat(container.getCurrentContainerInfo().getState().getStatus())
+                    .isEqualTo("running");
+            container.stop();
+        }
+    }
+
+    @Test
+    void s3ApiIsUsableAfterBootstrap() {
+        try (var container = new GarageContainer(IMAGE)) {
+            container.start();
+
+            try (var s3 = buildClient(container)) {
+                var key = "hello.txt";
+                var body = "hello garage";
+
+                s3.putObject(PutObjectRequest.builder()
+                                .bucket(container.getDefaultBucket())
+                                .key(key)
+                                .build(),
+                        RequestBody.fromString(body));
+
+                var fetched = s3.getObjectAsBytes(GetObjectRequest.builder()
+                        .bucket(container.getDefaultBucket())
+                        .key(key)
+                        .build());
+
+                assertThat(fetched.asString(StandardCharsets.UTF_8)).isEqualTo(body);
+            }
+        }
+    }
+
+    private static S3Client buildClient(GarageContainer container) {
+        return S3Client.builder()
+                .endpointOverride(URI.create(container.getS3Endpoint()))
+                .region(Region.of(container.getRegion()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(container.getAccessKey(), container.getSecretKey())))
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .chunkedEncodingEnabled(false)
+                        .build())
+                .build();
+    }
+
+}

--- a/docs/modules/dev-services/nav.adoc
+++ b/docs/modules/dev-services/nav.adoc
@@ -14,6 +14,8 @@
 ** xref:kafka.adoc[Kafka]
 ** xref:pulsar.adoc[Pulsar]
 ** xref:rabbitmq.adoc[RabbitMQ]
+* Object Stores
+** xref:garage.adoc[Garage]
 * Observability
 ** xref:lgtm.adoc[Grafana LGTM]
 ** xref:otel-collector.adoc[OpenTelemetry Collector]

--- a/docs/modules/dev-services/pages/garage.adoc
+++ b/docs/modules/dev-services/pages/garage.adoc
@@ -1,0 +1,71 @@
+= Garage Dev Service
+:service-name: garage
+
+A service providing a https://garagehq.deuxfleurs.fr[Garage] S3-compatible object store for development and testing purposes.
+
+It works with Spring Boot libraries that support the Amazon S3 API, including:
+
+* https://awspring.io[Spring Cloud AWS] (S3 client and `S3Template`)
+* https://aws.amazon.com/sdk-for-java/[AWS SDK for Java v2] (`S3Client`, `S3AsyncClient`)
+
+When Spring Cloud AWS is on the classpath, the Dev Service publishes an `AwsConnectionDetails` bean that wires endpoint, region, and credentials directly into the AWS clients via Spring Boot's `@ServiceConnection` mechanism. It also defaults `spring.cloud.aws.s3.path-style-access-enabled` to `true`, which is required by Garage.
+
+The container is bootstrapped automatically the first time it starts: cluster layout is assigned and applied, a deterministic access key is imported, and a default bucket is created and granted to that key.
+
+== Dependencies
+
+include::partial$dependencies.adoc[]
+
+== Running the Application
+
+include::partial$running-application.adoc[]
+
+== Configuring the Dev Service
+
+You can configure the Dev Service via configuration properties.
+
+|===
+|Property |Default |Description
+
+| `arconia.dev.services.{service-name}.enabled`
+| `true`
+| Whether the dev service is enabled.
+
+| `arconia.dev.services.{service-name}.image-name`
+| `dxflrs/garage:v2.3.0`
+| Full name of the container image used in the dev service.
+
+| `arconia.dev.services.{service-name}.environment`
+| `{}`
+| Environment variables to set in the service.
+
+| `arconia.dev.services.{service-name}.network-aliases`
+| `[]`
+| Network aliases to assign to the dev service container.
+
+| `arconia.dev.services.{service-name}.port`
+| `0`
+| Fixed port for exposing the Garage S3 API port to the host. When it's 0 (default), a random available port is assigned dynamically.
+
+| `arconia.dev.services.{service-name}.resources`
+| `[]`
+| Resources from the classpath or host filesystem to copy into the container. They can be files or directories that will be copied to the specified destination path inside the container at startup and are immutable (read-only).
+
+| `arconia.dev.services.{service-name}.shared`
+| `false`
+| Whether the dev service is shared among applications. Only applicable in dev mode.
+
+| `arconia.dev.services.{service-name}.startup-timeout`
+| `60s`
+| Maximum waiting time for the service to start.
+
+| `arconia.dev.services.{service-name}.volumes`
+| `[]`
+| Files or directories to mount from the host filesystem into the container. They are mounted at the specified destination path inside the container at startup and are mutable (read-write). Changes in either the host or the container will be immediately reflected in the other.
+
+| `arconia.dev.services.{service-name}.bucket-name`
+| `arconia`
+| Name of the bucket created automatically when the container starts.
+|===
+
+include::partial$disabling-dev-service.adoc[]

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ org.gradle.parallel=false
 
 org.gradle.jvmargs=-Xmx8g
 
+awsSdkVersion=2.42.36
 datasourceMicrometerSpringBootVersion=2.2.1
 doclingVersion=0.5.1
 jSpecifyVersion=1.0.0
@@ -14,4 +15,5 @@ openInferenceVersion=0.1.12
 openTelemetryInstrumentationVersion=2.27.0
 openTelemetrySemanticConventionsVersion=1.40.0
 springAiVersion=2.0.0-M5
+springCloudAwsVersion=4.0.2
 springCloudBindingsVersion=2.0.4

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,6 +20,7 @@ include 'arconia-dev:arconia-dev-services:arconia-dev-services-tests'
 
 include 'arconia-dev:arconia-dev-services:arconia-dev-services-artemis'
 include 'arconia-dev:arconia-dev-services:arconia-dev-services-docling'
+include 'arconia-dev:arconia-dev-services:arconia-dev-services-garage'
 include 'arconia-dev:arconia-dev-services:arconia-dev-services-kafka'
 include 'arconia-dev:arconia-dev-services:arconia-dev-services-lgtm'
 include 'arconia-dev:arconia-dev-services:arconia-dev-services-lldap'
@@ -71,6 +72,7 @@ include 'spring-boot-starters:arconia-opentelemetry-spring-boot-starter'
 include 'spring-boot-starters:arconia-spring-boot-starter'
 
 // Testcontainers
+include 'arconia-testcontainers:arconia-testcontainers-garage'
 include 'arconia-testcontainers:arconia-testcontainers-phoenix'
 include 'arconia-testcontainers:arconia-testcontainers-redis'
 include 'arconia-testcontainers:arconia-testcontainers-valkey'


### PR DESCRIPTION
## Summary

- Adds `arconia-testcontainers-garage` — a `GarageContainer` Testcontainers module for the [Garage](https://garagehq.deuxfleurs.fr) S3-compatible object store. The container auto-bootstraps cluster layout, imports a deterministic access key, and creates a default bucket on first start.
- Adds `arconia-dev-services-garage` — a Dev Service auto-configuration plus a `ContainerConnectionDetailsFactory<GarageContainer, AwsConnectionDetails>` that wires endpoint, region, and credentials directly into Spring Cloud AWS via Spring Boot's `@ServiceConnection` mechanism. A second auto-config defaults `spring.cloud.aws.s3.path-style-access-enabled=true` (required by Garage; not part of `AwsConnectionDetails`).
- Wires both modules in `settings.gradle`, `arconia-bom`, and the dev-services nav under a new "Object Stores" section. New `garage.adoc` page.

Closes #201

## Design notes

Implementation mirrors existing Arconia modules — structure, build files, packaging, and test scaffolding follow `arconia-testcontainers-redis` and `arconia-dev-services-redis`. The secondary autoconfig pattern follows `OllamaOpenAiDevServicesAutoConfiguration`.

`GarageContainerConnectionDetailsFactory` is modeled on Spring Cloud AWS's own `AwsContainerConnectionDetailsFactory` for LocalStack. `DevServiceDynamicPropertySource` (mentioned in the issue) was not used because `AwsConnectionDetails` already carries all required fields — the `@ServiceConnection` path is available and idiomatic.

Garage-specific deviations: log-message wait strategy (scratch image, no shell), `execInContainer()` bootstrap on `containerIsStarted()`, 60s startup timeout, and deterministic credentials via `garage key import`.

## Authorship disclosure

The entire codebase in this PR is written by AI coding agents working under human direction and review. The human author defined the requirements and architectural decisions, reviewed every change, and is accountable for the result.

## Verification disclosure

Beyond the tests included in this PR, the Dev Service has **not** been exercised locally yet — i.e. no end-to-end run from a real Spring Boot consumer application pulling in the starter, booting up, and using `S3Template` / `S3Client` against the auto-started Garage container. Reviewers should treat this as untested in that dimension.

## Test plan

- [x] `./gradlew :arconia-testcontainers:arconia-testcontainers-garage:build` (unit + IT, real S3 PutObject/GetObject through AWS SDK v2 against bootstrapped Garage)
- [x] `./gradlew :arconia-dev:arconia-dev-services:arconia-dev-services-garage:build` (16 unit tests + 1 IT verifying `AwsConnectionDetails` bean from running container)
- [x] `./gradlew :arconia-bom:build`
- [x] `./gradlew compileJava` (whole project)
- [ ] End-to-end consumer app smoke test (not yet performed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)