### PR TITLE
feat(dev): Added Spring Boot Dashboard to LGTM

### DIFF
--- a/arconia-dev/arconia-dev-services/arconia-dev-services-lgtm/src/main/java/io/arconia/dev/services/lgtm/ArconiaLgtmStackContainer.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-lgtm/src/main/java/io/arconia/dev/services/lgtm/ArconiaLgtmStackContainer.java
@@ -29,7 +29,7 @@ final class ArconiaLgtmStackContainer extends LgtmStackContainer implements DevS
 
     static final String DEFAULT_GRAFANA_DASHBOARD_PROVISIONING_PATH = "/otel-lgtm/grafana/conf/provisioning/dashboards";
 
-    static final String SPRING_BOOT_DASHBOARD_PROVIDER_FILE = "/spring-boot-dashboards.yaml";
+    static final String SPRING_BOOT_DASHBOARD_PROVIDER_FILE = "spring-boot-dashboards.yaml";
 
     private final String grafanaDashboardProvisioningPath;
 

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-lgtm/src/main/java/io/arconia/dev/services/lgtm/ArconiaLgtmStackContainer.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-lgtm/src/main/java/io/arconia/dev/services/lgtm/ArconiaLgtmStackContainer.java
@@ -1,11 +1,15 @@
 package io.arconia.dev.services.lgtm;
 
 import java.util.List;
+import java.nio.charset.StandardCharsets;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
 
+import io.arconia.dev.services.api.config.ResourceMapping;
+
 import org.testcontainers.grafana.LgtmStackContainer;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.images.builder.Transferable;
 
 import io.arconia.dev.services.api.registration.DevServiceLinkDefinition;
 import io.arconia.dev.services.api.registration.DevServiceLinkProvider;
@@ -20,6 +24,25 @@ final class ArconiaLgtmStackContainer extends LgtmStackContainer implements DevS
     private final LgtmDevServicesProperties properties;
 
     static final String COMPATIBLE_IMAGE_NAME = "grafana/otel-lgtm";
+
+    static final String SPRING_BOOT_DASHBOARDS_PATH = "/otel-lgtm/spring-boot-dashboards";
+
+    static final String GRAFANA_DASHBOARD_PROVISIONING_PATH = "/otel-lgtm/grafana/conf/provisioning/dashboards";
+
+    static final String SPRING_BOOT_DASHBOARD_PROVIDER = GRAFANA_DASHBOARD_PROVISIONING_PATH + "/arconia-dashboards.yaml";
+
+    String springBootDashboardsProvider() {
+        return """
+            apiVersion: 1
+
+            providers:
+              - name: Spring Boot
+                type: file
+                options:
+                  path: %s
+                  foldersFromFilesStructure: false
+            """.formatted(SPRING_BOOT_DASHBOARDS_PATH);
+    }
 
     static final int GRAFANA_PORT = 3000;
 
@@ -39,6 +62,7 @@ final class ArconiaLgtmStackContainer extends LgtmStackContainer implements DevS
 
         this.withEnv("GF_USERS_DEFAULT_THEME", "system");
         ContainerConfigurer.base(this, properties);
+        configureSpringBootDashboards();
     }
 
     @Override
@@ -76,6 +100,26 @@ final class ArconiaLgtmStackContainer extends LgtmStackContainer implements DevS
                 DevServiceLinkDefinition.builder().id("grafana").label("Grafana").port(GRAFANA_PORT).build(),
                 DevServiceLinkDefinition.builder().id("otlp-http").label("OTLP/HTTP").port(OTLP_HTTP_PORT).build(),
                 DevServiceLinkDefinition.builder().id("otlp-grpc").label("OTLP/gRPC").port(OTLP_GRPC_PORT).build());
+    }
+
+    private void configureSpringBootDashboards() {
+        if (!hasSpringBootDashboardResources()) {
+            return;
+        }
+
+        withCopyToContainer(Transferable.of(springBootDashboardsProvider().getBytes(StandardCharsets.UTF_8)), SPRING_BOOT_DASHBOARD_PROVIDER);
+    }
+
+    boolean hasSpringBootDashboardResources() {
+        return properties.getResources()
+                .stream()
+                .map(ResourceMapping::getContainerPath)
+                .anyMatch(this::isSpringBootDashboardPath);
+    }
+
+    private boolean isSpringBootDashboardPath(String containerPath) {
+        return containerPath.equals(SPRING_BOOT_DASHBOARDS_PATH)
+                || containerPath.startsWith(SPRING_BOOT_DASHBOARDS_PATH + "/");
     }
 
 }

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-lgtm/src/main/java/io/arconia/dev/services/lgtm/ArconiaLgtmStackContainer.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-lgtm/src/main/java/io/arconia/dev/services/lgtm/ArconiaLgtmStackContainer.java
@@ -27,22 +27,12 @@ final class ArconiaLgtmStackContainer extends LgtmStackContainer implements DevS
 
     static final String SPRING_BOOT_DASHBOARDS_PATH = "/otel-lgtm/spring-boot-dashboards";
 
-    static final String GRAFANA_DASHBOARD_PROVISIONING_PATH = "/otel-lgtm/grafana/conf/provisioning/dashboards";
+    static final String DEFAULT_GRAFANA_DASHBOARD_PROVISIONING_PATH = "/otel-lgtm/grafana/conf/provisioning/dashboards";
 
-    static final String SPRING_BOOT_DASHBOARD_PROVIDER = GRAFANA_DASHBOARD_PROVISIONING_PATH + "/arconia-dashboards.yaml";
+    static final String SPRING_BOOT_DASHBOARD_PROVIDER_FILE = "/spring-boot-dashboards.yaml";
 
-    String springBootDashboardsProvider() {
-        return """
-            apiVersion: 1
+    private final String grafanaDashboardProvisioningPath;
 
-            providers:
-              - name: Spring Boot
-                type: file
-                options:
-                  path: %s
-                  foldersFromFilesStructure: false
-            """.formatted(SPRING_BOOT_DASHBOARDS_PATH);
-    }
 
     static final int GRAFANA_PORT = 3000;
 
@@ -57,8 +47,13 @@ final class ArconiaLgtmStackContainer extends LgtmStackContainer implements DevS
     static final int PROMETHEUS_PORT = 9090;
 
     public ArconiaLgtmStackContainer(LgtmDevServicesProperties properties) {
+        this(properties, DEFAULT_GRAFANA_DASHBOARD_PROVISIONING_PATH);
+    }
+
+    public ArconiaLgtmStackContainer(LgtmDevServicesProperties properties, String grafanaDashboardProvisioningPath) {
         super(DockerImageName.parse(properties.getImageName()).asCompatibleSubstituteFor(COMPATIBLE_IMAGE_NAME));
         this.properties = properties;
+        this.grafanaDashboardProvisioningPath = grafanaDashboardProvisioningPath;
 
         this.withEnv("GF_USERS_DEFAULT_THEME", "system");
         ContainerConfigurer.base(this, properties);
@@ -107,7 +102,7 @@ final class ArconiaLgtmStackContainer extends LgtmStackContainer implements DevS
             return;
         }
 
-        withCopyToContainer(Transferable.of(springBootDashboardsProvider().getBytes(StandardCharsets.UTF_8)), SPRING_BOOT_DASHBOARD_PROVIDER);
+        withCopyToContainer(Transferable.of(springBootDashboardsProvider().getBytes(StandardCharsets.UTF_8)), springBootDashboardProviderPath());
     }
 
     boolean hasSpringBootDashboardResources() {
@@ -117,9 +112,26 @@ final class ArconiaLgtmStackContainer extends LgtmStackContainer implements DevS
                 .anyMatch(this::isSpringBootDashboardPath);
     }
 
+    String springBootDashboardsProvider() {
+        return """
+                apiVersion: 1
+
+                providers:
+                  - name: Spring Boot
+                    type: file
+                    options:
+                      path: %s
+                      foldersFromFilesStructure: false
+                """.formatted(SPRING_BOOT_DASHBOARDS_PATH);
+    }
+
     private boolean isSpringBootDashboardPath(String containerPath) {
         return containerPath.equals(SPRING_BOOT_DASHBOARDS_PATH)
                 || containerPath.startsWith(SPRING_BOOT_DASHBOARDS_PATH + "/");
+    }
+
+    private String springBootDashboardProviderPath() {
+        return grafanaDashboardProvisioningPath + "/" + SPRING_BOOT_DASHBOARD_PROVIDER_FILE;
     }
 
 }

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-lgtm/src/test/java/io/arconia/dev/services/lgtm/ArconiaLgtmStackContainerTests.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-lgtm/src/test/java/io/arconia/dev/services/lgtm/ArconiaLgtmStackContainerTests.java
@@ -1,6 +1,10 @@
 package io.arconia.dev.services.lgtm;
 
+import io.arconia.dev.services.api.config.ResourceMapping;
+
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -8,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit tests for {@link ArconiaLgtmStackContainer}.
  */
 class ArconiaLgtmStackContainerTests {
+
+    private static final String SPRING_BOOT_DASHBOARDS_PATH = "/otel-lgtm/spring-boot-dashboards";
 
     @Test
     void whenExposedPortsAreNotConfigured() {
@@ -45,6 +51,43 @@ class ArconiaLgtmStackContainerTests {
                         properties.getTempoPort() + ":" + ArconiaLgtmStackContainer.TEMPO_PORT))
                 .anyMatch(binding -> binding.startsWith(
                         properties.getPrometheusPort() + ":" + ArconiaLgtmStackContainer.PROMETHEUS_PORT));
+    }
+
+    @Test
+    void whenSpringBootDashboardIsNotConfigured() {
+        var properties = new LgtmDevServicesProperties();
+        var container = new ArconiaLgtmStackContainer(properties);
+
+        assertThat(container.getCopyToFileContainerPathMap()).doesNotContainValue(SPRING_BOOT_DASHBOARDS_PATH);
+    }
+
+    @Test
+    void whenSpringBootDashboardIsConfigured() {
+        var properties = springBootDashboardProperties();
+        var container = new ArconiaLgtmStackContainer(properties);
+
+        assertThat(container.getCopyToFileContainerPathMap()).containsValue(SPRING_BOOT_DASHBOARDS_PATH + "/spring-boot.json");
+    }
+
+    @Test
+    void whenSpringBootDashboardIsConfiguredThenProviderIsCorrect() {
+        var container = new ArconiaLgtmStackContainer(
+                springBootDashboardProperties());
+
+        assertThat(container.springBootDashboardsProvider())
+                .contains("apiVersion: 1")
+                .contains("name: Spring Boot")
+                .contains("type: file")
+                .contains("path: " + SPRING_BOOT_DASHBOARDS_PATH)
+                .contains("foldersFromFilesStructure: false");
+    }
+
+    private LgtmDevServicesProperties springBootDashboardProperties() {
+        var properties = new LgtmDevServicesProperties();
+        var resource = new ResourceMapping("classpath:grafana/spring-boot.json", SPRING_BOOT_DASHBOARDS_PATH+"/spring-boot.json");
+        properties.setResources(List.of(resource));
+
+        return properties;
     }
 
 }

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-lgtm/src/test/java/io/arconia/dev/services/lgtm/LgtmDevServicesAutoConfigurationIT.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-lgtm/src/test/java/io/arconia/dev/services/lgtm/LgtmDevServicesAutoConfigurationIT.java
@@ -1,5 +1,9 @@
 package io.arconia.dev.services.lgtm;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -10,6 +14,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.grafana.LgtmStackContainer;
 import org.testcontainers.junit.jupiter.EnabledIfDockerAvailable;
 
+import io.arconia.dev.services.api.config.ResourceMapping;
 import io.arconia.dev.services.api.registration.DevServiceLabels;
 import io.arconia.dev.services.api.registration.DevServiceLink;
 import io.arconia.dev.services.api.registration.DevServiceLinkProvider;
@@ -139,6 +144,54 @@ class LgtmDevServicesAutoConfigurationIT extends BaseDevServicesAutoConfiguratio
                     container.start();
                     assertThatConfigurationIsApplied(container);
                     container.stop();
+                });
+    }
+
+    @Test
+    void springBootDashboardResourceIsConfigured() {
+        getContextRunner()
+                .withPropertyValues(
+                        "arconia.dev.services.lgtm.resources[0].source-path="
+                                + "classpath:grafana/spring-boot.json",
+                        "arconia.dev.services.lgtm.resources[0].container-path="
+                                + "/otel-lgtm/spring-boot-dashboards/spring-boot.json")
+                .run(context -> {
+                    var container = context.getBean(ArconiaLgtmStackContainer.class);
+
+                    assertThat(container.hasSpringBootDashboardResources()).isTrue();
+                });
+    }
+
+    @Test
+    void springBootDashboardIsLoaded() {
+        getContextRunner()
+                .withPropertyValues(
+                        "arconia.dev.services.lgtm.resources[0].source-path="
+                                + "classpath:grafana/spring-boot.json",
+                        "arconia.dev.services.lgtm.resources[0].container-path="
+                                + "/otel-lgtm/spring-boot-dashboards/spring-boot.json")
+                .run(context -> {
+                    var container = context.getBean(ArconiaLgtmStackContainer.class);
+
+                    container.start();
+                    try {
+                        var grafanaUrl = "http://%s:%d"
+                                .formatted(container.getHost(), container.getMappedPort(ArconiaLgtmStackContainer.GRAFANA_PORT));
+
+                        var request = HttpRequest.newBuilder()
+                                .uri(URI.create(grafanaUrl + "/api/search"))
+                                .GET()
+                                .build();
+
+                        var response = HttpClient.newHttpClient()
+                                .send(request, HttpResponse.BodyHandlers.ofString());
+
+                        assertThat(response.statusCode()).isEqualTo(200);
+                        assertThat(response.body())
+                                .contains("Spring Boot Test Dashboard");
+                    } finally {
+                        container.stop();
+                    }
                 });
     }
 

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-lgtm/src/test/java/io/arconia/dev/services/lgtm/LgtmDevServicesAutoConfigurationIT.java
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-lgtm/src/test/java/io/arconia/dev/services/lgtm/LgtmDevServicesAutoConfigurationIT.java
@@ -14,7 +14,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.grafana.LgtmStackContainer;
 import org.testcontainers.junit.jupiter.EnabledIfDockerAvailable;
 
-import io.arconia.dev.services.api.config.ResourceMapping;
 import io.arconia.dev.services.api.registration.DevServiceLabels;
 import io.arconia.dev.services.api.registration.DevServiceLink;
 import io.arconia.dev.services.api.registration.DevServiceLinkProvider;

--- a/arconia-dev/arconia-dev-services/arconia-dev-services-lgtm/src/test/resources/grafana/spring-boot.json
+++ b/arconia-dev/arconia-dev-services/arconia-dev-services-lgtm/src/test/resources/grafana/spring-boot.json
@@ -1,0 +1,7 @@
+{
+  "title": "Spring Boot Test Dashboard",
+  "uid": "spring-boot-test",
+  "schemaVersion": 39,
+  "version": 1,
+  "panels": []
+}


### PR DESCRIPTION
Hi @ThomasVitale 

- Implemented support for **Spring Boot Grafana dashboards in the LGTM Dev Service** using the existing Arconia **resource mappings** mechanism.
- Dashboard files can be supplied from the application project through `arconia.dev.services.lgtm.resources`, using `source-path` and `container-path`
- Updated `ArconiaLgtmStackContainer` to react to **dashboard resource mappings** and automatically configure Grafana dashboard provisioning.
- Added a Grafana provisioning YAML(`spring-boot-dashboards.yaml`) using the Grafana file provider, pointing to the configured Spring Boot dashboard directory.
- Kept the actual Grafana dashboard as **JSON**; the YAML is only the Grafana provisioning configuration.
- Verified the `grafana/otel-lgtm:0:30.1` image structure using Docker commands to identify the Grafana installation and provisioning directories.
- Specifically verified the container paths with commands such as:

```
docker run --rm grafana/otel-lgtm:0.30.1 \
  find /otel-lgtm/grafana/conf/provisioning/dashboards -maxdepth 2 -type f -print
```
and inspected the existing provisioning configuration with:

```
docker run --rm grafana/otel-lgtm:0.30.1 \
  sh -c 'cat /otel-lgtm/grafana/conf/provisioning/dashboards/grafana-dashboards.yaml
```

- Also verified the Grafana executable and CLI location inside the image:

```

docker run --rm grafana/otel-lgtm:0.30.1 \
  find /otel-lgtm -type f \( -name "grafana" -o -name "grafana-cli" \) -print
```
which showed `/otel-lgtm/grafana/bin/grafana`; the CLI was investigated, but dashboard provisioning is handled through Grafana's file provisioning mechanism rather than the CLI.


Could you please review it and let me know your feedback

Thanks,
Mahendra