### PR TITLE
docs: Clarify Arize AX and Phoenix observability paths

### DIFF
--- a/docs/modules/dev-services/pages/phoenix.adoc
+++ b/docs/modules/dev-services/pages/phoenix.adoc
@@ -1,7 +1,9 @@
 = Arize Phoenix Dev Service
 :service-name: phoenix
 
-A service providing https://arize.com/docs/phoenix[Arize Phoenix], an AI Observability and Evaluation platform based on OpenTelemetry and OpenInference, for development and testing purposes.
+A service providing https://arize.com/docs/phoenix[Arize Phoenix], an open-source AI Observability and Evaluation platform based on OpenTelemetry and OpenInference, for development and testing purposes.
+
+For managed production observability and evaluation, use https://arize.com/docs/ax/integrations/java/arconia/arconia-tracing[Arize AX] with Arconia's OpenInference telemetry. See Arize's guides to learn how traces support https://arize.com/guides/ai-agent-handbook/agent-evaluation/[agent evaluation] and https://arize.com/resources/llm-evaluation/[LLM evaluation].
 
 It works with Spring Boot libraries that support OpenTelemetry, including:
 

--- a/docs/modules/observability/pages/semantic-conventions/openinference.adoc
+++ b/docs/modules/observability/pages/semantic-conventions/openinference.adoc
@@ -5,6 +5,8 @@ Spring AI provides built-in instrumentation for models, vector stores, and workf
 
 Arconia provides a Phoenix Dev Service you can use during development and testing. Check out the xref:dev-services:phoenix.adoc[Phoenix Dev Service] documentation for more details.
 
+For production deployments, https://arize.com/docs/ax/integrations/java/arconia/arconia-tracing[Arize AX] provides a managed path for tracing, monitoring, and evaluating Arconia-based Spring AI applications. Arize Phoenix remains the open-source and self-hosted option for local development or team-managed deployments. The Arize guides for https://arize.com/guides/ai-agent-handbook/agent-evaluation/[agent evaluation] and https://arize.com/resources/llm-evaluation/[LLM evaluation] explain how trace data can be used to inspect agent behavior, evaluate model outputs, and improve reliability over time.
+
 [WARNING]
 ====
 The https://arize-ai.github.io/openinference/spec/[OpenInference Semantic Conventions] are still experimental, and they might change in the future.


### PR DESCRIPTION
## Description

Clarifies the Arize positioning in the OpenInference semantic conventions and Phoenix Dev Service docs:

- describes Phoenix as the open-source option for local development and self-hosted workflows
- points production Arconia users to the Arize AX tracing documentation
- links Arize's agent evaluation and LLM evaluation guides for teams using OpenInference traces to evaluate agent behavior and model outputs

This is a docs-only update.

Fixes: N/A - documentation clarification only.

## Checklist

- [x] I have reviewed and followed the [contributing guidelines](https://github.com/arconia-io/arconia/blob/main/CONTRIBUTING.md).
- [ ] I have run a local build and made sure all tests pass (`./gradlew build`).
- [x] I have signed off the [Developer Certificate of Origin (DCO)](https://github.com/arconia-io/arconia/blob/main/dco.txt).
- [x] I assert that I have read the [Arconia Code of Conduct](https://github.com/arconia-io/arconia/blob/main/CODE_OF_CONDUCT.md) and agree to abide by it.

Validation run locally:

- `git diff --check`

I did not run `./gradlew build` because the change only updates docs prose.